### PR TITLE
Allow building for multiple platforms (zynq and zynqmp)

### DIFF
--- a/CONFIG.example
+++ b/CONFIG.example
@@ -19,7 +19,12 @@
 # is specified it will be prepended to the path for building the driver and
 # target server.
 #
-# BINUTILS_DIR = /dls_sw/FPGA/Xilinx/SDK/2015.1/gnu/arm/lin/bin
+# TOOLCHAIN_ROOT = /dls_sw/FPGA/Xilinx/SDK/2015.1/gnu/arm/lin
+#
+# Additionally, if the toolchain uses a vendor specific compiler prefix, we
+# need:
+#
+# COMPILER_PREFIX = arm-xilinx-linux-gnueabi
 
 # Where the kernel was compiled.  Use PandABlocks-rootfs to build this.  This is
 # only required if building the driver target.
@@ -33,5 +38,9 @@
 # List of default targets build when running make
 #
 # DEFAULT_TARGETS = driver server sim_server docs
+#
+# Whether it will run in platform zynq or zynqmp
+#
+# PLATFORM = zynq
 
 # vim: set filetype=make:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TOP := $(CURDIR)
 BUILD_DIR = $(TOP)/build
 PYTHON = python
 SPHINX_BUILD = sphinx-build
+COMPILER_PREFIX = $(COMPILER_PREFIX_$(PLATFORM))
 KERNEL_DIR = $(error Define KERNEL_DIR in CONFIG file)
 PANDA_ROOTFS = $(error Define PANDA_ROOTFS in CONFIG file)
 PLATFORM = $(error Define PLATFORM in CONFIG file)
@@ -28,7 +29,6 @@ ARCH = $(ARCH_$(PLATFORM))
 # Cross-compilation tuple for toolkit
 COMPILER_PREFIX_zynq = arm-none-linux-gnueabihf
 COMPILER_PREFIX_zynqmp = aarch64-none-linux-gnu
-COMPILER_PREFIX = $(COMPILER_PREFIX_$(PLATFORM))
 CROSS_COMPILE = $(COMPILER_PREFIX)-
 CC = $(CROSS_COMPILE)gcc
 

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,9 @@ TOP := $(CURDIR)
 BUILD_DIR = $(TOP)/build
 PYTHON = python
 SPHINX_BUILD = sphinx-build
-CROSS_COMPILE = arm-xilinx-linux-gnueabi-
-BINUTILS_DIR =
 KERNEL_DIR = $(error Define KERNEL_DIR in CONFIG file)
 PANDA_ROOTFS = $(error Define PANDA_ROOTFS in CONFIG file)
+PLATFORM = $(error Define PLATFORM in CONFIG file)
 MAKE_ZPKG = $(PANDA_ROOTFS)/make-zpkg
 MAKE_GITHUB_RELEASE = $(PANDA_ROOTFS)/make-github-release.py
 
@@ -22,8 +21,15 @@ DEFAULT_TARGETS = driver server sim_server docs zpkg
 # and editing as appropriate.
 include CONFIG
 
+ARCH_zynq = arm
+ARCH_zynqmp = arm64
+ARCH = $(ARCH_$(PLATFORM))
 
-ARCH = arm
+# Cross-compilation tuple for toolkit
+COMPILER_PREFIX_zynq = arm-none-linux-gnueabihf
+COMPILER_PREFIX_zynqmp = aarch64-none-linux-gnu
+COMPILER_PREFIX = $(COMPILER_PREFIX_$(PLATFORM))
+CROSS_COMPILE = $(COMPILER_PREFIX)-
 CC = $(CROSS_COMPILE)gcc
 
 DRIVER_BUILD_DIR = $(BUILD_DIR)/driver
@@ -34,8 +40,12 @@ DOCS_BUILD_DIR = $(BUILD_DIR)/html
 DRIVER_FILES := $(wildcard driver/*)
 SERVER_FILES := $(wildcard server/*)
 
+ifdef TOOLCHAIN_ROOT
+BINUTILS_DIR ?= $(TOOLCHAIN_ROOT)
+endif
+
 ifdef BINUTILS_DIR
-PATH := $(BINUTILS_DIR):$(PATH)
+PATH := $(BINUTILS_DIR)/bin:$(PATH)
 endif
 
 default: $(DEFAULT_TARGETS)

--- a/driver/panda_stream.c
+++ b/driver/panda_stream.c
@@ -223,9 +223,10 @@ static int allocate_blocks(struct stream_open *open)
     int rc = 0;
     int blk = 0;
     printk(KERN_INFO "Allocate %dx %d blocks\n", block_count, BUF_BLOCK_SIZE);
+    struct block *block;
     for (; blk < block_count; blk ++)
     {
-        struct block *block = &open->blocks[blk];
+        block = &open->blocks[blk];
         block->block = (void *) __get_free_pages(GFP_KERNEL, block_shift);
         TEST_OK(block->block,
             rc = -ENOMEM, no_block, "Unable to allocate buffer");
@@ -242,7 +243,7 @@ static int allocate_blocks(struct stream_open *open)
      * we allocated, in reverse order. */
     do {
         blk -= 1;
-        struct block *block = &open->blocks[blk];
+        block = &open->blocks[blk];
         dma_unmap_single(dev, block->dma, BUF_BLOCK_SIZE, DMA_FROM_DEVICE);
 no_dma_map:
         free_pages((unsigned long) block->block, block_shift);

--- a/server/slow_load.c
+++ b/server/slow_load.c
@@ -51,7 +51,13 @@ static void assert_fail(const char *filename, int linenumber)
 
 /* This offset is added to each GPIO number to map from hardware pin number to
  * kernel identifier. */
+#ifdef __aarch64__
+// GPIO offset when platform is zynqmp
+#define GPIO_OFFSET     338
+#else
+// GPIO offset when platform is zynq
 #define GPIO_OFFSET     906
+#endif
 
 /* The table below is initialised with the GPIO offset for the physical pin used
  * for the GPIO function. */

--- a/server/slow_load.c
+++ b/server/slow_load.c
@@ -268,7 +268,7 @@ static bool program_FPGA(void)
 
     /* STEP-5: Read firmware binary file */
     printf("Programming FPGA...\n");
-    int len;
+    ssize_t len;
     unsigned char StreamData[4096];
     int block = 0;
     while (


### PR DESCRIPTION
We are using a more standard ARM toolchain (from ARM), which required minor tweaks.
The variable PLATFORM can be `zynq` or `zynqmp`  to select the platform. The toolchain is configured via the variable TOOLCHAIN_ROOT.
Here is an example CONFIG:
```
TOOLCHAIN_ROOT = /dls_sw/targetOS/x-tools/gcc-10.2.1-glibc-2.31/$(COMPILER_PREFIX)
PANDA_ROOTFS = /dls_sw/work/panda2xu5/PandABlocks-rootfs
KERNEL_DIR = /scratch/tmp/PandA-rootfs-zynqmp/build/linux
PLATFORM = zynqmp
```