### PR TITLE
added PCAP ARM timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /simserver
 *.pyc
 tests/fpga_sequences
+/venv

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /simserver
 *.pyc
 tests/fpga_sequences
-/venv
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /simserver
 *.pyc
 tests/fpga_sequences
-
+/venv

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -138,6 +138,7 @@ Data Header
 At the beginning of each experiment the following information is sent:
 
 =============== ================================================================
+arm_time        UTC Timestamp sampled in correspondence of the ARM command
 missed          Number of samples missed by late data port connection.
 process         Data processing option: Scaled, Unscaled, or Raw.
 format          Data delivery formatting: ASCII, Base64, Framed, or Unframed.
@@ -213,6 +214,7 @@ Some examples of data capture for different options follow:
 
 Default::
 
+    arm_time: 2021-05-26T10:34:06.133Z
     missed: 0
     process: Scaled
     format: ASCII
@@ -231,6 +233,7 @@ Default::
 
 ``BASE64``::
 
+    arm_time: 2021-05-26T10:34:06.133Z
     missed: 0
     process: Scaled
     format: Base64
@@ -249,7 +252,7 @@ Default::
 ``XML``::
 
     <header>
-    <data missed="0" process="Scaled" format="ASCII" />
+    <data arm_time="2021-05-26T10:35:06.107Z" missed="0" process="Scaled" format="ASCII" />
     <fields>
     <field name="PCAP.CAPTURE_TS" type="double" capture="Trigger" />
     <field name="COUNTER1.OUT" type="double" capture="Triggered" scale="1"

--- a/server/Makefile
+++ b/server/Makefile
@@ -38,7 +38,7 @@ CFLAGS += -Wmissing-declarations
 CFLAGS += -Wstrict-prototypes
 CFLAGS += -Wcast-qual
 CFLAGS += -Woverflow
-#CFLAGS += -Wconversion
+CFLAGS += -Wconversion
 
 CFLAGS += -fstrict-overflow
 CFLAGS += -Wsign-compare

--- a/server/Makefile
+++ b/server/Makefile
@@ -38,7 +38,7 @@ CFLAGS += -Wmissing-declarations
 CFLAGS += -Wstrict-prototypes
 CFLAGS += -Wcast-qual
 CFLAGS += -Woverflow
-CFLAGS += -Wconversion
+#CFLAGS += -Wconversion
 
 CFLAGS += -fstrict-overflow
 CFLAGS += -Wsign-compare

--- a/server/data_server.c
+++ b/server/data_server.c
@@ -97,9 +97,7 @@ static struct capture_buffer *data_buffer;
 static const struct captured_fields *captured_fields;
 static const struct data_capture *data_capture;
 /* PCAP ARM timestamp */
-static struct timespec ts;
-static struct tm tm;
-static char timestamp_message[MAX_RESULT_LENGTH];
+static struct timespec pcap_arm_ts;
 
 /* Data completion code at end of experiment. */
 static unsigned int completion_code;
@@ -198,12 +196,7 @@ error__t arm_capture(void)
     unsigned int readers, active;
 
     // get PCAP ARM timestamp and store as a global
-    clock_gettime(CLOCK_REALTIME, &ts);
-    gmtime_r(&ts.tv_sec, &tm);
-    snprintf(timestamp_message, sizeof(timestamp_message),
-        "%4d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
-        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-        tm.tm_hour, tm.tm_min, tm.tm_sec, ts.tv_nsec / 1000000);
+    clock_gettime(CLOCK_REALTIME, &pcap_arm_ts);
 
     return
         TEST_OK_(check_pcap_valid(),
@@ -675,7 +668,7 @@ error__t process_data_socket(int scon)
             if (!connection.options.omit_header)
                 ok = send_data_header(
                     captured_fields, data_capture,
-                    &connection.options, connection.file, lost_samples, timestamp_message);
+                    &connection.options, connection.file, lost_samples, &pcap_arm_ts);
 
             uint64_t sent_samples = 0;
             if (ok)

--- a/server/data_server.c
+++ b/server/data_server.c
@@ -195,9 +195,6 @@ error__t arm_capture(void)
 {
     unsigned int readers, active;
 
-    // get PCAP ARM timestamp and store as a global
-    clock_gettime(CLOCK_REALTIME, &pcap_arm_ts);
-
     return
         TEST_OK_(check_pcap_valid(),
             "PCAP not supported with this configuration")  ?:
@@ -208,6 +205,8 @@ error__t arm_capture(void)
              * buffer status to be idle. */
             TEST_OK(!read_buffer_status(data_buffer, &readers, &active))  ?:
             TEST_OK_(active == 0, "Data clients still taking data")  ?:
+            /* Get PCAP ARM timestamp and store as a global */
+            TEST_IO(clock_gettime(CLOCK_REALTIME, &pcap_arm_ts))  ?:
             start_data_capture());
 }
 

--- a/server/data_server.c
+++ b/server/data_server.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <pthread.h>
+#include <time.h>
 
 #include "error.h"
 #include "hardware.h"
@@ -95,6 +96,10 @@ static struct capture_buffer *data_buffer;
  * data capture is enabled, invalid otherwise. */
 static const struct captured_fields *captured_fields;
 static const struct data_capture *data_capture;
+/* PCAP ARM timestamp */
+static struct timespec ts;
+static struct tm tm;
+static char timestamp_message[MAX_RESULT_LENGTH];
 
 /* Data completion code at end of experiment. */
 static unsigned int completion_code;
@@ -191,6 +196,15 @@ static error__t start_data_capture(void)
 error__t arm_capture(void)
 {
     unsigned int readers, active;
+
+    // get PCAP ARM timestamp and store as a global
+    clock_gettime(CLOCK_REALTIME, &ts);
+    gmtime_r(&ts.tv_sec, &tm);
+    snprintf(timestamp_message, sizeof(timestamp_message),
+        "%4d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
+        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+        tm.tm_hour, tm.tm_min, tm.tm_sec, ts.tv_nsec / 1000000);
+
     return
         TEST_OK_(check_pcap_valid(),
             "PCAP not supported with this configuration")  ?:
@@ -661,7 +675,7 @@ error__t process_data_socket(int scon)
             if (!connection.options.omit_header)
                 ok = send_data_header(
                     captured_fields, data_capture,
-                    &connection.options, connection.file, lost_samples);
+                    &connection.options, connection.file, lost_samples, timestamp_message);
 
             uint64_t sent_samples = 0;
             if (ok)

--- a/server/prepare.c
+++ b/server/prepare.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
+#include <time.h>
 
 #include "error.h"
 #include "parse.h"
@@ -287,6 +288,20 @@ static void send_capture_info(
 
     struct xml_element element =
         start_element(file, "data", options->xml_header, false, true);
+    
+    // valerix begin
+    struct timespec ts;
+    struct tm tm;
+    char message[MAX_RESULT_LENGTH];
+    clock_gettime(CLOCK_REALTIME, &ts);
+    localtime_r(&ts.tv_sec, &tm);
+    snprintf(message, sizeof(message),
+        "%4d-%02d-%02d %02d:%02d:%02d.%03ld",
+        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+        tm.tm_hour, tm.tm_min, tm.tm_sec, ts.tv_nsec / 1000000);
+    format_attribute(&element, "PCAP ARM time", "%s", message);
+    // valerix end
+    
     format_attribute(&element, "missed", "%"PRIu64, missed_samples);
     format_attribute(&element, "process", "%s", data_process);
     format_attribute(&element, "format", "%s", data_format);

--- a/server/prepare.h
+++ b/server/prepare.h
@@ -46,7 +46,7 @@ bool send_data_header(
     const struct captured_fields *fields,
     const struct data_capture *capture,
     const struct data_options *options,
-    struct buffered_file *file, uint64_t lost_samples);
+    struct buffered_file *file, uint64_t lost_samples, char *timestamp_message);
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/server/prepare.h
+++ b/server/prepare.h
@@ -46,7 +46,7 @@ bool send_data_header(
     const struct captured_fields *fields,
     const struct data_capture *capture,
     const struct data_options *options,
-    struct buffered_file *file, uint64_t lost_samples, char *timestamp_message);
+    struct buffered_file *file, uint64_t lost_samples, struct timespec *pcap_arm_tsp);
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
Hi. I added a timestamp in the streaming header when the PCAP block is armed; this should solve issue #7 . Anyway, the header is now different from before (it has one more line), so it might not be backward-compatible.
