### PR TITLE
Extension helper

### DIFF
--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -99,3 +99,41 @@ takes one argument and must support two methods `parse_read` and `parse_write`
             `write-reg` block of the register file.  The returned values will be
             written to the specified hardware registers after processing this
             function.  This defines the action of writing this field.
+
+
+Injected Values
+---------------
+
+Every extension module will have two support values injected into the module
+when the module is loaded into the server.  These are available to help with the
+implementation of extensions.
+
+..  class:: ServerError(Exception)
+
+    Read and write methods should use this exception to report errors.
+    Exceptions of this type are treated specially and are reported as normal
+    read or write errors.
+
+..  class:: ExtensionHelper
+
+    This can be used inside an extension module to create extension support for
+    individual fields.  Pass a block constructor (that must take one argument,
+    the block index) which implements `set_` and `get_` methods as appropriate,
+    and this helper will implement the approprate Extension support.
+
+    Use this inside the extension module thus::
+
+        class MyBlock:
+            def __init__(self, n):
+                ...
+
+            def get_field(self, *regs):
+                ...
+                return value
+
+            def set_field(self, value, *regs):
+                ...
+                return new_regs
+
+        def Extension(count):
+          return ExtensionHelper(MyBlock, count)

--- a/python/extension_server
+++ b/python/extension_server
@@ -14,15 +14,52 @@ class ServerError(Exception):
     pass
 
 
+# This can be used inside an extension module to create extension support for
+# individual fields.  Pass a block constructor (that must take one argument, the
+# block index) which implements set_ and get_ methods as appropriate, and this
+# helper will implement the approprate Extension support.
+#
+# Use this inside the extension module thus:
+#
+#   class MyBlock: ...
+#   def Extension(count):
+#       return ExtensionHelper(MyBlock, count)
+#
+class ExtensionHelper:
+    def __init__(self, block_class, count):
+        self.block_class = block_class
+        self.blocks = [block_class(n) for n in range(count)]
+
+    def parse_read(self, field):
+        # Pick up unbound read method
+        get_field = getattr(self.block_class, 'get_%s' % field, None)
+        if get_field is None:
+            raise ServerError('Cannot read from field %r' % field)
+        def reader(block, *regs):
+            return get_field(self.blocks[block], *regs)
+        return reader
+
+    def parse_write(self, field):
+        # Pick up unbound write method
+        set_field = getattr(self.block_class, 'set_%s' % field, None)
+        if set_field is None:
+            raise ServerError('Cannot write to field %r' % field)
+        def writer(block, value, *regs):
+            return set_field(self.blocks[block], value, *regs)
+        return writer
+
+
 # Imports the named module from the extensions directory.
 def import_extension_module(name):
     try:
         module = import_module('%s.%s' % (extension_module, name))
     except ImportError as e:
-        raise ServerError('Extension module %r not found' % name)
+        raise ServerError(e)
 
-    # Inject the ServerError exception into the module so it can use this
+    # Inject the ServerError exception and ExtensionHelper into the module so it
+    # can use these
     module.ServerError = ServerError
+    module.ExtensionHelper = ExtensionHelper
     return module
 
 

--- a/python/extension_server
+++ b/python/extension_server
@@ -48,7 +48,8 @@ class IdTable:
 class Extensions:
     def __init__(self):
         self.block_ids = IdTable('block')
-        self.field_ids = IdTable('field')
+        self.reader_ids = IdTable('reader')
+        self.writer_ids = IdTable('writer')
 
     def parse_block(self, line):
         # Syntax:   field-count module-name
@@ -64,23 +65,21 @@ class Extensions:
         block = self.block_ids[block_id]
 
         if rw == 'R':
-            parse = block.parse_read(parse_args)
+            return self.reader_ids.add_entity(block.parse_read(parse_args))
         elif rw == 'W':
-            parse = block.parse_write(parse_args)
+            return self.writer_ids.add_entity(block.parse_write(parse_args))
         else:
             raise ServerError('Invalid R/W field in parse')
-
-        return self.field_ids.add_entity(parse)
 
     def read(self, line):
         # Syntax:   parse-id field-num [read-regs]*
         args = [int(arg) for arg in line.split(' ')]
-        return self.field_ids[args[0]].read(*args[1:])
+        return self.reader_ids[args[0]](*args[1:])
 
     def write(self, line):
         # Syntax:   parse-id field-num value [read-regs]*
         args = [int(arg) for arg in line.split(' ')]
-        result = self.field_ids[args[0]].write(*args[1:])
+        result = self.writer_ids[args[0]](*args[1:])
 
         # The return from result can be None, which we treat as an empty list,
         # otherwise it must be a tuple of register values to be written.

--- a/python/sim_config/config
+++ b/python/sim_config/config
@@ -343,6 +343,10 @@ DUMMY[5]
     POLY_R          read
     POLY_W          write
 
+INTERVAL[3]
+    CENTRE          param
+    RANGE           param
+
 SFP_RX
     PARAM           param
     BITA            bit_out

--- a/python/sim_config/registers
+++ b/python/sim_config/registers
@@ -254,6 +254,10 @@ DUMMY           29 dummy
     POLY_R          0 1 2 3 X poly
     POLY_W          0 1 2 3 W 0 1 2 3 4 X poly
 
+INTERVAL        30 interval
+    CENTRE          W 0 1 X centre
+    RANGE           W 0 1 X range
+
 SFP_RX      S31
     PARAM           0
     BITA            127

--- a/python/test_extension/dummy.py
+++ b/python/test_extension/dummy.py
@@ -43,7 +43,7 @@ class Extension:
         return self.fields[name]
 
     def parse_read(self, node):
-        return self.make_field(node)
+        return self.make_field(node).read
 
     def parse_write(self, node):
-        return self.make_field(node)
+        return self.make_field(node).write

--- a/python/test_extension/interval.py
+++ b/python/test_extension/interval.py
@@ -1,0 +1,24 @@
+from __future__ import division
+
+# Simple conversion from centre/range to start end interval
+
+class Range:
+    def __init__(self, n):
+        self.centre = 0
+        self.range = 0
+
+    def set_centre(self, centre):
+        self.centre = centre
+        return self._interval()
+
+    def set_range(self, range):
+        self.range = range
+        return self._interval()
+
+    def _interval(self):
+        start = self.centre - self.range // 2
+        return (start, start + self.range)
+
+
+def Extension(count):
+    return ExtensionHelper(Range, count)

--- a/python/test_extension/system.py
+++ b/python/test_extension/system.py
@@ -28,4 +28,4 @@ class Extension:
         assert count == 1, 'Only one system block expected'
 
     def parse_read(self, node):
-        return XADC(node)
+        return XADC(node).read

--- a/tests/extension_script
+++ b/tests/extension_script
@@ -10,14 +10,14 @@ P0
 
 # and a write field with the same name
 PW0 blah
-P1
+P0
 
 # Initial read value is 0
 R0 3
 R0
 
 # Now write to the field
-W1 3 999
+W0 3 999
 W
 
 # Field now reads new value
@@ -26,17 +26,17 @@ R999
 
 # Create poly fields
 PR0 poly
-P2
+P1
 
 PW0 poly
-P3
+P1
 
 # Testing reading from a poly field
-R2 99 1 2 3 4
+R1 99 1 2 3 4
 R10
 
 # Writing to a poly field
-W3 99 1 2 3 4
+W1 99 1 2 3 4
 W4 3 2 1
 
 # Parse unknown block
@@ -53,7 +53,7 @@ EInvalid block id '999'
 
 # Read with invalid field
 R999 99
-EInvalid field id 999
+EInvalid reader id 999
 
 # Send extra values to field which isn't expecting it
 R0 3 1 2 3 4

--- a/tests/extension_script
+++ b/tests/extension_script
@@ -41,7 +41,7 @@ W4 3 2 1
 
 # Parse unknown block
 B1 unknown
-EExtension module 'unknown' not found
+ENo module named unknown
 
 # Invalid command
 xx

--- a/tests/transcript
+++ b/tests/transcript
@@ -50,6 +50,7 @@
 > !COUNTER 8
 > !ADDER 2
 > !CLOCKS 1
+> !INTERVAL 3
 > !SYSTEM 1
 > !BITS 1
 > !QDEC 4


### PR DESCRIPTION
Add `ExtensionHelper` class and example extension [interval.py](https://github.com/PandABlocks/PandABlocks-server/blob/extension-helper/python/test_extension/interval.py), as discussed in https://github.com/PandABlocks/PandABlocks-FPGA/issues/51.