### PR TITLE
Update zpkg filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ clean-docs:
 
 ZPKG_DEPENDS = $(PANDA_KO) $(SERVER) $(SLOW_LOAD) $(DOCS_BUILD_DIR)/index.html
 
-ZPKG = $(BUILD_DIR)/panda-server@$(GIT_VERSION).zpg
+ZPKG = $(BUILD_DIR)/panda-server@$(PLATFORM)-$(GIT_VERSION).zpg
 
 $(ZPKG): etc/panda-server.list $(ZPKG_DEPENDS)
 	rm -f $(BUILD_DIR)/*.zpg


### PR DESCRIPTION
With the addition of CI, the zpkgs will be automatically built and uploaded as artifacts for each platform. To distinguish between these files, the zpkgs will now include the target platform as part of the output filename.