### PR TITLE
Remove !nm from simserver target

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -154,7 +154,6 @@ server: $(SRCS:.c=.o) hw_hardware.o
 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 sim_server: $(SRCS:.c=.o) sw_hardware.o sim_hardware.o
-	! nm $^ | grep ' [CD] '
 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 %.d: %.c


### PR DESCRIPTION
This !nm command causes an error when executed in Ubuntu. This causes an immediate failure in the CI test job which runs on Ubuntu-latest. Removing this bypasses the error with negligible effects on the rest of the code. 

Reported error from CI test job:
```
! nm server.o version.o locking.o persistence.o error.o socket_server.o config_server.o data_server.o buffer.o buffered_file.o parse.o utf8_check.o parse_lut.o hashtable.o database.o config_command.o system_command.o fields.o types.o enums.o attributes.o pos_mux.o ext_out.o bit_out.o pos_out.o output.o prepare.o capture.o time.o table.o register.o base64.o metadata.o mac_address.o extension.o sw_hardware.o sim_hardware.o | grep ' [CD] '
0000000000000000 D entity_commands
0000000000000000 D system_commands
0000000000000000 D enum_type_methods
0000000000000000 D pos_mux_class_methods
0000000000000020 D ext_out_class_methods
make[1]: *** [/home/runner/work/PandABlocks-server/PandABlocks-server/PandABlocks-server/server/Makefile:157: sim_server] Error 1
```