### PR TITLE
Remove UNSCALED capture option

### DIFF
--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -88,14 +88,13 @@ BASE64      Binary data will be sent as a stream of base64 strings.          1
 FRAMED      Binary data is sent as a sequence of sized frames.               1
 UNFRAMED    Binary data is sent as a raw stream of bytes.                    1 R
 SCALED      All scalable data is scaled and sent as doubles.                 2 D
-UNSCALED    Averages are calculated but all values are sent as integers.     2 R
 RAW         The captured binary data is sent without processing.             2
 NO_HEADER   The data header is omitted.                                        R
 NO_STATUS   The connection and end of experiment status strings are            R
             omitted.
 ONE_SHOT    Only one experiment will be transmitted.                           R
 XML         The header will be sent in XML format.
-BARE        Selects ``UNFRAMED UNSCALED NO_HEADER NO_STATUS ONE_SHOT``
+BARE        Selects ``UNFRAMED RAW NO_HEADER NO_STATUS ONE_SHOT``
 DEFAULT     Default options.                                                   D
 =========== ================================================================ = =
 

--- a/server/prepare.c
+++ b/server/prepare.c
@@ -43,8 +43,6 @@ static error__t parse_one_option(
     /* Data processing options. */
     else if (strcmp(option, "RAW") == 0)
         options->data_process = DATA_PROCESS_RAW;
-    else if (strcmp(option, "UNSCALED") == 0)
-        options->data_process = DATA_PROCESS_UNSCALED;
     else if (strcmp(option, "SCALED") == 0)
         options->data_process = DATA_PROCESS_SCALED;
 
@@ -63,7 +61,7 @@ static error__t parse_one_option(
     else if (strcmp(option, "BARE") == 0)
         *options = (struct data_options) {
             .data_format = DATA_FORMAT_UNFRAMED,
-            .data_process = DATA_PROCESS_UNSCALED,
+            .data_process = DATA_PROCESS_RAW,
             .omit_header = true,
             .omit_status = true,
             .one_shot = true,
@@ -248,12 +246,6 @@ static const char *field_type_name(
             [CAPTURE_MODE_AVERAGE]  = "int64",
             [CAPTURE_MODE_UNSCALED] = "uint32",
         },
-        [DATA_PROCESS_UNSCALED] = {
-            [CAPTURE_MODE_SCALED32] = "int32",
-            [CAPTURE_MODE_SCALED64] = "int64",
-            [CAPTURE_MODE_AVERAGE]  = "int32",
-            [CAPTURE_MODE_UNSCALED] = "uint32",
-        },
         [DATA_PROCESS_SCALED] = {
             [CAPTURE_MODE_SCALED32] = "double",
             [CAPTURE_MODE_SCALED64] = "double",
@@ -280,7 +272,6 @@ static void send_capture_info(
     };
     static const char *data_process_strings[] = {
         [DATA_PROCESS_RAW]      = "Raw",
-        [DATA_PROCESS_UNSCALED] = "Unscaled",
         [DATA_PROCESS_SCALED]   = "Scaled",
     };
     const char *data_format = data_format_strings[options->data_format];

--- a/server/prepare.h
+++ b/server/prepare.h
@@ -13,7 +13,6 @@ enum data_format {
 
 enum data_process {
     DATA_PROCESS_RAW,       // Unprocessed raw captured data
-    DATA_PROCESS_UNSCALED,  // Integer numbers
     DATA_PROCESS_SCALED,    // Floating point scaled numbers
 };
 


### PR DESCRIPTION
I think I'm happy with this now.

Removes `UNSCALED` data capture option on the grounds that
1. It's kind of complicated to implement
2. Nobody actually wants to use it
3. It raises questions about how to implement the new upcoming StdDev option

There is one associated change, the `BARE` data capture option now returns `RAW` data.

This commit only removes code (and updates docs accordingly).

Address issue #24 