### PR TITLE
Get start timestamp and add it to header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 
 - Fix error in scalar value formatting (github issue #29)
 - Add ``*BITS?`` command to return available bit bus entry names
+- Capture timestamp when PCAP becomes armed and enabled
 
 3.0a3_ - 2022-05-03
 -------------------

--- a/config_d/registers
+++ b/config_d/registers
@@ -4,7 +4,7 @@
 # set in *DRV changes or if the FPGA changes in any other way that requires a
 # driver change.  The driver will refuse to load if this does not match the
 # value returned by *DRV.DRV_COMPAT_VERSION
-DRIVER_COMPAT_VERSION = 0
+DRIVER_COMPAT_VERSION = 1
 
 # PandA Blocks compatibility version.  This is checked by the server when
 # loading the registers file, and should be updated when the interface to the

--- a/driver/panda_device.h
+++ b/driver/panda_device.h
@@ -30,3 +30,5 @@ struct panda_block {
 #define PANDA_COMPLETION_FRAMING    2
 #define PANDA_COMPLETION_DMA        4
 #define PANDA_COMPLETION_OVERRUN    8
+
+#define PANDA_GET_START_TS _IOR('P', 4, struct timespec64)

--- a/driver/panda_stream.c
+++ b/driver/panda_stream.c
@@ -28,12 +28,10 @@
 static int block_shift = 9;     // In log2 pages, default is 2MB
 static int block_count = 32;    // Number of buffers in circular buffer
 static int block_timeout = 12500000;    // 100ms in 125MHz FPGA clock ticks
-static int verbose = 0;
 
 module_param(block_shift, int, S_IRUGO);
 module_param(block_count, int, S_IRUGO);
 module_param(block_timeout, int, S_IRUGO);
-module_param(verbose, int, S_IRUGO);
 
 #define BUF_BLOCK_SIZE      (1U << (block_shift + PAGE_SHIFT))
 

--- a/server/data_server.c
+++ b/server/data_server.c
@@ -142,6 +142,10 @@ static void capture_experiment(void)
         total_bytes += count;
         experiment_sample_count = total_bytes / sample_length;
     }
+
+    if (!ts_captured)
+        release_write_block(data_buffer, 0);
+
     completion_code = hw_read_streamed_completion();
 
     end_write(data_buffer);

--- a/server/hardware.h
+++ b/server/hardware.h
@@ -1,4 +1,5 @@
 /* Hardware interface definitions. */
+#include <time.h>
 
 #define BIT_BUS_COUNT       128
 #define POS_BUS_COUNT       32
@@ -159,6 +160,9 @@ size_t hw_read_streamed_data(void *buffer, size_t length, bool *data_end);
 unsigned int hw_read_streamed_completion(void);
 /* Converts the completion code into a printable string. */
 const char *hw_decode_completion(unsigned int completion);
+
+/* This function gets the timestamp when PCAP becomes armed and enabled */
+void hw_get_start_ts(struct timespec *ts);
 
 /* This function controls the arm/disarm state of data capture.  Data capture is
  * armed by writing true with this function, after which hw_read_streamed_data()

--- a/server/prepare.h
+++ b/server/prepare.h
@@ -46,7 +46,7 @@ bool send_data_header(
     const struct data_capture *capture,
     const struct data_options *options,
     struct buffered_file *file, uint64_t lost_samples,
-    struct timespec *pcap_arm_tsp);
+    struct timespec *pcap_arm_tsp, struct timespec *pcap_start_tsp);
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/server/sim_hardware.c
+++ b/server/sim_hardware.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -179,6 +180,12 @@ size_t hw_read_streamed_data(void *buffer, size_t length, bool *data_end)
 
 void hw_write_arm_streamed_data(void) { }
 uint32_t hw_read_streamed_completion(void) { return 0; }
+
+
+void hw_get_start_ts(struct timespec *ts)
+{
+    clock_gettime(CLOCK_REALTIME, ts);
+}
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
This requires that the readers wait for the start of the acquisition.

`struct timespec` doesn't match the timespec we get from the kernel module, on top of that, it could have different sizes in 32-bit and 64-bit architecture, a cast between an intermediate structure was used to workaround this.

This fixes https://github.com/PandABlocks/PandABlocks-server/issues/7