### PR TITLE
Use a reasonable size of the backlog for the extension server socket 

### DIFF
--- a/python/extension_server
+++ b/python/extension_server
@@ -131,7 +131,7 @@ class Server:
         self.server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_sock.bind(('localhost', port))
-        self.server_sock.listen(0)
+        self.server_sock.listen(1)
         # Will be filled in by self.run()
         self.file = None
         self.ext = None


### PR DESCRIPTION
Since python 3.5, the backlog parameter is optional and it will
use a default reasonable value. Using value 0 was causing the
following message in linux logs:
TCP: request_sock_TCP: Possible SYN flooding on port 9999...