### PR TITLE
Use new *REG.NOMINAL_CLOCK register to define clock frequency

### DIFF
--- a/config_d/registers
+++ b/config_d/registers
@@ -50,6 +50,11 @@ BLOCKS_COMPAT_VERSION = 0
     # Range of MAC addresses
     MAC_ADDRESS_BASE        16 .. 23
 
+    # Nominal clock.  If this register is non zero the value returned will be
+    # used as the reported clock frequency in Hz, otherwise the standard
+    # frequency of 125 MHz will be reported and used.
+    NOMINAL_CLOCK           24
+
 
 # These registers are used by the kernel driver to read the data capture stream.
 # This block is not used by the server, but is here for documentation and other

--- a/config_d/registers
+++ b/config_d/registers
@@ -76,4 +76,4 @@ BLOCKS_COMPAT_VERSION = 0
 
     # Kernel driver compatiblity version check register.  The value in this
     # register must match DRIVER_COMPAT_VERSION.
-    DRV_COMPAT_VERSION      7
+    COMPAT_VERSION          7

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -163,6 +163,9 @@ below:
 | ``*SAVESTATE=``               | Triggers immediate save to file of the       |
 |                               | persistence file state.                      |
 +-------------------------------+----------------------------------------------+
+| ``*CLOCK_FREQ?``              | Returns currently configured system clock    |
+|                               | frequency                                    |
++-------------------------------+----------------------------------------------+
 
 ``*IDN?``
     Returns system identification string, for example the following::
@@ -398,3 +401,7 @@ below:
     launched) with the current state.  Returns after a file system ``sync``
     call, so it is safe to power-off the system after this command has
     completed.
+
+``*CLOCK_FREQ?``
+    Returns currently configured FPGA clock frequency as used to convert between
+    times in natural units and times in clock ticks.

--- a/driver/panda_core.c
+++ b/driver/panda_core.c
@@ -80,7 +80,7 @@ static int panda_probe(struct platform_device *pdev)
     pcap->irq = rc;
 
     /* Check the driver and FPGA protocol version match. */
-    TEST_OK(readl(pcap->reg_base + DRV_COMPAT_VERSION) == DRIVER_COMPAT_VERSION,
+    TEST_OK(readl(pcap->reg_base + COMPAT_VERSION) == DRIVER_COMPAT_VERSION,
         rc = -EINVAL, bad_version, "Driver compatibility version mismatch");
 
     /* Create character device support. */

--- a/server/config_server.c
+++ b/server/config_server.c
@@ -90,7 +90,7 @@ uint64_t update_change_index(
         else
             /* If this change isn't to be reported, push the report index out to
              * the indefinite future. */
-            reported[i] = (uint64_t) (int64_t) -1;
+            reported[i] = UINT64_MAX;
     return change_index;
 }
 

--- a/server/ext_out.c
+++ b/server/ext_out.c
@@ -177,7 +177,7 @@ static void get_capture_info(
         .capture_mode = get_capture_mode(ext_out->ext_type),
         .capture_string = "Value",
         /* Scaling info only used for timestamp fields. */
-        .scale = 1.0 / CLOCK_FREQUENCY,
+        .scale = 1.0 / hw_read_nominal_clock(),
         .offset = 0.0,
         .units = "s",
     };

--- a/server/hardware.c
+++ b/server/hardware.c
@@ -253,6 +253,16 @@ uint32_t hw_read_fpga_capabilities(void)
 }
 
 
+uint32_t hw_read_nominal_clock(void)
+{
+    uint32_t frequency = read_named_register(NOMINAL_CLOCK);
+    if (frequency > 0)
+        return frequency;
+    else
+        return NOMINAL_CLOCK_FREQUENCY;
+}
+
+
 /******************************************************************************/
 /* Data capture. */
 

--- a/server/hardware.h
+++ b/server/hardware.h
@@ -8,7 +8,7 @@
 #define MAX_PCAP_WRITE_COUNT    64
 
 
-#define CLOCK_FREQUENCY 125000000       // 8ns per tick
+#define NOMINAL_CLOCK_FREQUENCY 125000000       // 8ns per tick
 #define MAX_CLOCK_VALUE ((1ULL << 48) - 1)
 
 
@@ -99,6 +99,9 @@ void hw_write_mac_address(unsigned int offset, uint64_t mac_address);
 
 /* Returns the value of the FPGA capabilities register. */
 uint32_t hw_read_fpga_capabilities(void);
+
+/* Returns the currently configured nominal clock frequency in Hz. */
+uint32_t hw_read_nominal_clock(void);
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/server/system_command.c
+++ b/server/system_command.c
@@ -464,6 +464,16 @@ static error__t put_savestate(
 }
 
 
+/* *CLOCK_FREQ?
+ *
+ * Returns current configured clock frequency. */
+static error__t get_clock_freq(
+    const char *command, struct connection_result *result)
+{
+    return format_one_result(result, "%d", hw_read_nominal_clock());
+}
+
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* System command dispatch. */
 
@@ -495,6 +505,7 @@ static const struct command_table_entry command_table_list[] = {
     { "ENUMS",      true,  .get = get_enums, },
     { "PCAP",       true,  .get = get_pcap,     .put = put_pcap, },
     { "SAVESTATE",  false, .put = put_savestate, },
+    { "CLOCK_FREQ", false, .get = get_clock_freq, },
 };
 
 static struct hash_table *command_table;


### PR DESCRIPTION
This is used in all conversion functions, and can be reported by a new *CLOCK_FREQ? command.

Note that in this commit any saved time settings are stored in seconds (or other natural units) and will be converted accordingly.