### PR TITLE
Prevent use of bounce buffer in targets with 4GB of memory

### DIFF
--- a/driver/panda_block.c
+++ b/driver/panda_block.c
@@ -85,8 +85,9 @@ static int create_block(
         open->block.block_length < pcap->length - 4,
         rc = -EINVAL, bad_request, "Invalid register argument for block");
 
-    /* Ok, all in order.  Allocate the requested block and map it for DMA. */
-    open->block_addr = (void *) __get_free_pages(GFP_KERNEL, open->block.order);
+    /* Ok, all in order.  Allocate the requested block and map it for DMA.
+     * Flag GFP_DMA32 is set to avoid using bounce buffer. */
+    open->block_addr = (void *) __get_free_pages(GFP_KERNEL | GFP_DMA32, open->block.order);
     TEST_OK(open->block_addr, rc = -ENOMEM, bad_request,
         "Unable to allocate block");
     open->dma = dma_map_single(

--- a/driver/panda_stream.c
+++ b/driver/panda_stream.c
@@ -242,7 +242,8 @@ static int allocate_blocks(struct stream_open *open)
     for (; blk < block_count; blk ++)
     {
         block = &open->blocks[blk];
-        block->block = (void *) __get_free_pages(GFP_KERNEL, block_shift);
+        /* Flag GFP_DMA32 is set to avoid using bounce buffer */
+        block->block = (void *) __get_free_pages(GFP_KERNEL | GFP_DMA32, block_shift);
         TEST_OK(block->block,
             rc = -ENOMEM, no_block, "Unable to allocate buffer");
         block->dma =


### PR DESCRIPTION
This fixes the following error while mapping the DMA buffer: panda a0000000.panda_pcap: swiotlb buffer is full (sz: 2097152 bytes),
    total 32768 (slots), used 0 (slots)

Linux has a memory zone for the first 2GB and will allocate from it when passing the flag GFP_DMA32 to the allocating function.

There is still the question of why linux assumes a bounce buffer is needed when the buffer is allocated in the highest 2GB.