### PR TITLE
Add hardware timestamp in the pcap capture header

### DIFF
--- a/config_d/registers
+++ b/config_d/registers
@@ -40,6 +40,10 @@ BLOCKS_COMPAT_VERSION = 0
     PCAP_START_WRITE        8
     PCAP_WRITE              9
 
+    # Hardware timestamps
+    PCAP_TS_SEC             10
+    PCAP_TS_NSEC            11
+
     # Position capture control
     PCAP_ARM                13
     PCAP_DISARM             14

--- a/config_d/registers
+++ b/config_d/registers
@@ -42,7 +42,7 @@ BLOCKS_COMPAT_VERSION = 0
 
     # Hardware timestamps
     PCAP_TS_SEC             10
-    PCAP_TS_NSEC            11
+    PCAP_TS_TICKS           11
 
     # Position capture control
     PCAP_ARM                13

--- a/config_d/registers
+++ b/config_d/registers
@@ -42,9 +42,9 @@ BLOCKS_COMPAT_VERSION = 0
 
     # Hardware timestamps
     # This starts at unix epoch (UTC)
-    PCAP_TS_SEC             10
+    PCAP_TS_SEC             opt 10
     # Ticks since PCAP_TS_SEC was updated
-    PCAP_TS_TICKS           11
+    PCAP_TS_TICKS           opt 11
 
     # Position capture control
     PCAP_ARM                13

--- a/config_d/registers
+++ b/config_d/registers
@@ -41,7 +41,9 @@ BLOCKS_COMPAT_VERSION = 0
     PCAP_WRITE              9
 
     # Hardware timestamps
+    # This starts at unix epoch (UTC)
     PCAP_TS_SEC             10
+    # Ticks since PCAP_TS_SEC was updated
     PCAP_TS_TICKS           11
 
     # Position capture control

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -152,7 +152,9 @@ sample_bytes      Number of bytes in one sample unless ``format`` is ``ASCII``.
 fields            Information about each captured field.
 ================= ==============================================================
 
-All timestamps are in `ISO 8601 UTC format <https://en.wikipedia.org/wiki/ISO_8601>`_, i.e. ``YYYY-MM-DDTHH:mm:ss.sssZ``.
+All timestamps are in
+`ISO 8601 UTC format <https://en.wikipedia.org/wiki/ISO_8601>`_ with nanosecond
+resolution, i.e. ``YYYY-MM-DDTHH:mm:ss.sssssssssZ``.
 
 ``start_time`` will be a hardware timestamp if a hardware time source which
 produces non-zero timestamps is selected, otherwise, it will be a system

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -136,14 +136,23 @@ Data Header
 
 At the beginning of each experiment the following information is sent:
 
-=============== ================================================================
-arm_time        UTC Timestamp sampled in correspondence of the ARM command
-missed          Number of samples missed by late data port connection.
-process         Data processing option: Scaled, Unscaled, or Raw.
-format          Data delivery formatting: ASCII, Base64, Framed, or Unframed.
-sample_bytes    Number of bytes in one sample unless ``format`` is ``ASCII``.
-fields          Information about each captured field.
-=============== ================================================================
+================= ==============================================================
+arm_time          System timestamp when ARM command was sent
+start_time        Timestamp of when PCAP became both armed and enabled
+hw_time_offset_ns Offset in ns from hardware timestamp to captured system time,
+                  only present when hardware time source is used.
+missed            Number of samples missed by late data port connection.
+process           Data processing option: Scaled, Unscaled, or Raw.
+format            Data delivery formatting: ASCII, Base64, Framed, or Unframed.
+sample_bytes      Number of bytes in one sample unless ``format`` is ``ASCII``.
+fields            Information about each captured field.
+================= ==============================================================
+
+All timestamps are unix time.
+
+``start_time`` will be a hardware timestamp if a hardware time source which
+produces non-zero timestamps is selected, otherwise, it will be a system
+timestamp saved by the driver.
 
 For each field the following information is sent:
 

--- a/docs/capture.rst
+++ b/docs/capture.rst
@@ -138,9 +138,13 @@ At the beginning of each experiment the following information is sent:
 
 ================= ==============================================================
 arm_time          System timestamp when ARM command was sent
-start_time        Timestamp of when PCAP became both armed and enabled
-hw_time_offset_ns Offset in ns from hardware timestamp to captured system time,
-                  only present when hardware time source is used.
+start_time        Timestamp of when PCAP became both armed and enabled.
+                  Uses hardware provided timestamp (e.g. from event receiver)
+                  if available, falling back to the system timestamp.
+hw_time_offset_ns Offset in ns from hardware timestamp to system time at the
+                  start of the experiment. Only present when hardware time
+                  source is used. Used to check that hardware and system times
+                  have not drifted too far apart.
 missed            Number of samples missed by late data port connection.
 process           Data processing option: Scaled, Unscaled, or Raw.
 format            Data delivery formatting: ASCII, Base64, Framed, or Unframed.
@@ -148,7 +152,7 @@ sample_bytes      Number of bytes in one sample unless ``format`` is ``ASCII``.
 fields            Information about each captured field.
 ================= ==============================================================
 
-All timestamps are unix time.
+All timestamps are in `ISO 8601 UTC format <https://en.wikipedia.org/wiki/ISO_8601>`_, i.e. ``YYYY-MM-DDTHH:mm:ss.sssZ``.
 
 ``start_time`` will be a hardware timestamp if a hardware time source which
 produces non-zero timestamps is selected, otherwise, it will be a system

--- a/server/data_server.c
+++ b/server/data_server.c
@@ -118,15 +118,16 @@ static void update_start_timestamp(void)
     struct timespec pcap_drv_start_ts, pcap_hw_start_ts;
     hw_get_start_ts(&pcap_drv_start_ts);
     hw_get_hw_start_ts(&pcap_hw_start_ts);
-    if (pcap_hw_start_ts.tv_sec == 0 && pcap_hw_start_ts.tv_nsec == 0) {
+    if (pcap_hw_start_ts.tv_sec == 0 && pcap_hw_start_ts.tv_nsec == 0)
+    {
         pcap_start_ts = pcap_drv_start_ts;
         pcap_hw_ts_offset_ns_valid = false;
-    } else {
-        int64_t drv_ts_num =
-            (int64_t) pcap_drv_start_ts.tv_sec * 1000000000
+    }
+    else
+    {
+        int64_t drv_ts_num = (int64_t) pcap_drv_start_ts.tv_sec * NSECS
             + pcap_drv_start_ts.tv_nsec;
-        int64_t hw_ts_num =
-            (int64_t) pcap_hw_start_ts.tv_sec * 1000000000
+        int64_t hw_ts_num = (int64_t) pcap_hw_start_ts.tv_sec * NSECS
             + pcap_hw_start_ts.tv_nsec;
         pcap_start_ts = pcap_hw_start_ts;
         pcap_hw_ts_offset_ns = drv_ts_num - hw_ts_num;

--- a/server/database.c
+++ b/server/database.c
@@ -126,6 +126,10 @@ static error__t register_parse_special_field(
     return
         parse_name(line, reg_name, sizeof(reg_name))  ?:
         parse_whitespace(line)  ?:
+        /* Some register definitions are optional and are flagged as such for
+         * processing by hardware.h, but we want to ignore this flag when
+         * dynamically loading the same file. */
+        DO(read_string(line, "opt"))  ?:
         parse_uint(line, &reg)  ?:
         IF_ELSE(**line,
             parse_whitespace(line)  ?:

--- a/server/hardware.c
+++ b/server/hardware.c
@@ -324,6 +324,13 @@ void hw_get_start_ts(struct timespec *ts)
     ts->tv_nsec = (typeof(ts->tv_nsec)) compat_ts.tv_nsec;
 }
 
+
+void hw_get_hw_start_ts(struct timespec *ts)
+{
+    ts->tv_sec = (time_t) read_named_register(PCAP_TS_SEC);
+    ts->tv_nsec = (typeof(ts->tv_nsec)) read_named_register(PCAP_TS_NSEC);
+}
+
 #endif
 
 

--- a/server/hardware.c
+++ b/server/hardware.c
@@ -328,7 +328,10 @@ void hw_get_start_ts(struct timespec *ts)
 void hw_get_hw_start_ts(struct timespec *ts)
 {
     ts->tv_sec = (time_t) read_named_register(PCAP_TS_SEC);
-    ts->tv_nsec = (typeof(ts->tv_nsec)) read_named_register(PCAP_TS_NSEC);
+    ts->tv_nsec = (typeof(ts->tv_nsec)) ((uint64_t)
+        read_named_register(PCAP_TS_TICKS) * NSECS / hw_read_nominal_clock());
+    ts->tv_sec += ts->tv_nsec / NSECS;
+    ts->tv_nsec = ts->tv_nsec % NSECS;
 }
 
 #endif

--- a/server/hardware.c
+++ b/server/hardware.c
@@ -97,6 +97,7 @@ struct named_register {
     const char *name;
     unsigned int range;
     bool seen;
+    bool optional;
 };
 
 /* Similar structure for named constants. */
@@ -166,7 +167,7 @@ error__t hw_validate(void)
     for (unsigned int i = 0; i < ARRAY_SIZE(named_registers); i ++)
     {
         struct named_register *reg = &named_registers[i];
-        if (reg->name  &&  !reg->seen)
+        if (reg->name  &&  !reg->seen  &&  !reg->optional)
             return FAIL_("Register %s not in *REG list", reg->name);
     }
     for (unsigned int i = 0; i < ARRAY_SIZE(named_constants); i ++)

--- a/server/hardware.h
+++ b/server/hardware.h
@@ -165,9 +165,9 @@ unsigned int hw_read_streamed_completion(void);
 const char *hw_decode_completion(unsigned int completion);
 
 /* This function gets the timestamp when PCAP becomes armed and enabled */
-void hw_get_start_ts(struct timespec *ts);
+bool hw_get_start_ts(struct timespec *ts);
 /* This one is latched in hardware instead of the driver */
-void hw_get_hw_start_ts(struct timespec *ts);
+bool hw_get_hw_start_ts(struct timespec *ts);
 
 /* This function controls the arm/disarm state of data capture.  Data capture is
  * armed by writing true with this function, after which hw_read_streamed_data()

--- a/server/hardware.h
+++ b/server/hardware.h
@@ -166,6 +166,8 @@ const char *hw_decode_completion(unsigned int completion);
 
 /* This function gets the timestamp when PCAP becomes armed and enabled */
 void hw_get_start_ts(struct timespec *ts);
+/* This one is latched in hardware instead of the driver */
+void hw_get_hw_start_ts(struct timespec *ts);
 
 /* This function controls the arm/disarm state of data capture.  Data capture is
  * armed by writing true with this function, after which hw_read_streamed_data()

--- a/server/named_registers.py
+++ b/server/named_registers.py
@@ -14,6 +14,9 @@ base, fields = blocks['*REG']
 # followed by a range.
 def fixup_fields(name, value):
     values = value.split()
+    optional = values[0] == 'opt'
+    if optional:
+        values = values[1:]
     start = int(values[0])
     if values[1:]:
         middle, end = values[1:]
@@ -21,7 +24,7 @@ def fixup_fields(name, value):
         count = int(end) - start + 1
     else:
         count = 1
-    return name, start, count
+    return name, start, count, optional
 
 fields = [fixup_fields(name, value) for name, value in fields]
 
@@ -39,14 +42,14 @@ print('''\
 # First generate the #define statements
 print('#define REG_BLOCK_BASE %s' % base)
 print()
-for name, value, _ in fields:
+for name, value, _, _ in fields:
     print('#define %s %s' % (name, value))
 
 # Now generate offset name table used for checking.
 print('''
 static struct named_register named_registers[] = {''')
-for name, _, count in fields:
-    print('    [%s] = { "%s", %d, false },' % (name, name, count))
+for name, _, count, opt in fields:
+    print('    [%s] = { "%s", %d, false, %d },' % (name, name, count, opt))
 print('};')
 
 # Generate table of constants read from config file

--- a/server/prepare.c
+++ b/server/prepare.c
@@ -268,9 +268,9 @@ static void format_timestamp_message(
     struct tm tm;
     gmtime_r(&tsp->tv_sec, &tm);
     snprintf(timestamp_message, max_len,
-        "%4d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
+        "%4d-%02d-%02dT%02d:%02d:%02d.%09ldZ",
         tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-        tm.tm_hour, tm.tm_min, tm.tm_sec, tsp->tv_nsec / 1000000);
+        tm.tm_hour, tm.tm_min, tm.tm_sec, tsp->tv_nsec);
 }
 
 

--- a/server/prepare.h
+++ b/server/prepare.h
@@ -46,7 +46,8 @@ bool send_data_header(
     const struct data_capture *capture,
     const struct data_options *options,
     struct buffered_file *file, uint64_t lost_samples,
-    struct timespec *pcap_arm_tsp, struct timespec *pcap_start_tsp);
+    struct timespec *pcap_arm_tsp, struct timespec *pcap_start_tsp,
+    bool pcap_hw_ts_offset_ns_valid, int64_t pcap_hw_ts_offset_ns);
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/server/sim_hardware.c
+++ b/server/sim_hardware.c
@@ -188,6 +188,13 @@ void hw_get_start_ts(struct timespec *ts)
 }
 
 
+void hw_get_hw_start_ts(struct timespec *ts)
+{
+    ts->tv_sec = 0;
+    ts->tv_nsec = 0;
+}
+
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Long table support. */
 

--- a/server/sim_hardware.c
+++ b/server/sim_hardware.c
@@ -182,16 +182,18 @@ void hw_write_arm_streamed_data(void) { }
 uint32_t hw_read_streamed_completion(void) { return 0; }
 
 
-void hw_get_start_ts(struct timespec *ts)
+bool hw_get_start_ts(struct timespec *ts)
 {
     clock_gettime(CLOCK_REALTIME, ts);
+    return true;
 }
 
 
-void hw_get_hw_start_ts(struct timespec *ts)
+bool hw_get_hw_start_ts(struct timespec *ts)
 {
     ts->tv_sec = 0;
     ts->tv_nsec = 0;
+    return true;
 }
 
 


### PR DESCRIPTION
If the hardware timestamp is not 0, it will be used as start time and a new offset field will be updated with the difference with the system time.

For more information see issue PandABlocks/PandABlocks-FPGA#172.

This PR requires the associated change in PandABlocks-FPGA to be merged, in particular, the implementation of registers PCAP_TS_SEC (offset 10) and PCAP_TS_TICKS (offset 11) is required.