### PR TITLE
Make it easy to view debug output from PandA server

### DIFF
--- a/etc/panda-server
+++ b/etc/panda-server
@@ -5,7 +5,8 @@
 . /etc/init.d/functions
 
 # File locations
-pidfile=/var/run/panda-server.pid
+server_pid_file=/var/run/panda-server.pid
+extension_pid_file=/var/run/panda-extensions.pid
 
 panda_server=/opt/bin/panda_server
 panda_config=/opt/share/panda-fpga/config_d
@@ -58,19 +59,38 @@ do_start()
         i=$((i+1))
     done  &&
 
-    # Now start the extension server
-    $extension_server -d -s $extension_dir  &&
-
-    # Finally start the PANDA server
-    $panda_server \
-        -c $panda_config -f $panda_state -P $pidfile -D -R -X 9999 \
-        -r "$(head -n1 /etc/version)" \
-        $panda_server_mac
+    # Now start the extension server (in procServ if available)
+    {
+        if type procServ &> /dev/null; then
+            procServ -n panda-extensions -p $extension_pid_file \
+                -L /var/log/panda-extensions-console 8021 \
+                $extension_server -s $extension_dir
+        else
+            $extension_server -d -s $extension_dir -P $extension_pid_file
+        fi
+    } &&
+    {
+        # Finally start the PANDA server (in procServ if available)
+        if type procServ &> /dev/null; then
+            procServ -n panda-server -p $server_pid_file \
+                -L /var/log/panda-server-console 8022 \
+                $panda_server \
+                    -c $panda_config -f $panda_state -R -X 9999 \
+                    -r "$(head -n1 /etc/version)" \
+                    $panda_server_mac
+        else
+            $panda_server \
+                -c $panda_config -f $panda_state -P $server_pid_file -D -R \
+                -X 9999 -r "$(head -n1 /etc/version)" \
+                $panda_server_mac
+        fi
+    }
 }
 
 do_stop()
 {
-    kill -HUP $(cat $pidfile)  &&
+    kill $(cat $server_pid_file)  &&
+    kill $(cat $extension_pid_file) &&
 
     # Remove the Panda driver.  We have to keep trying because we can't actually
     # unload it until the server has finished shutting down.

--- a/python/extension_server
+++ b/python/extension_server
@@ -3,6 +3,7 @@
 # Extension server for custom fields implemented outside the core server
 
 import argparse
+import atexit
 import os
 import sys
 from importlib import import_module
@@ -254,6 +255,7 @@ parser.add_argument(
 parser.add_argument(
     '-n', '--normalise_exceptions', action = 'store_true',
     help = 'Normalise exception messages reported by server.  Testing only')
+parser.add_argument('-P', '--pidfile', help = 'Save PID to file specified')
 parser.add_argument(
     'extensions', help = 'Extension directory')
 command_args = parser.parse_args()
@@ -292,6 +294,12 @@ logging.info('Extension server ready')
 # This ensures that when our caller gets control the connection will succeed.
 if command_args.daemon:
     daemonise()
+
+if command_args.pidfile:
+    with open(command_args.pidfile, 'w') as fhandle:
+        fhandle.write(f'{os.getpid()}')
+
+    atexit.register(lambda: os.unlink(command_args.pidfile))
 
 try:
     server.run()


### PR DESCRIPTION
That simplifies checking investigation when there are problems. Additionally, extension server pid file support was added so that it can be killed when running without procServ.

This fixes PandABlocks/PandABlocks-server#50.