### PR TITLE
Fix GATE_DURATION duplication in RAW mode

### DIFF
--- a/server/capture.c
+++ b/server/capture.c
@@ -392,17 +392,17 @@ static bool ensure_sample_count(
 {
     struct data_capture *capture = gather->capture;
 
-    /* Search the unscaled captures for a sample matching the sample count. */
+    /* Search the scaled32 captures for a sample matching the sample count. */
     unsigned int sample_count_capture =
         fields->sample_count->capture_index.index[0];
-    for (unsigned int i = 0; i < fields->unscaled.count; i ++)
+    for (unsigned int i = 0; i < fields->scaled32.count; i ++)
     {
-        struct capture_info *field = fields->unscaled.outputs[i];
+        struct capture_info *field = fields->scaled32.outputs[i];
         if (field->capture_index.index[0] == sample_count_capture)
         {
-            /* Already being captured.  Because the unscaled group goes first
-             * and we're the only entry, this is the right index. */
-            capture->sample_count_index = i;
+            /* Already being captured.  Because the scaled32 group goes second,
+             * we need to add the unscaled group count. */
+            capture->sample_count_index = fields->unscaled.count + i;
             /* Sample count is in a group, not anonymous */
             return false;
         }


### PR DESCRIPTION
`ensure_sample_count` is responsible for finding sample count if it was already captured and we need it for a mean or std_dev capture. The problem was the it was looking for it in the wrong capture group, it should be the scaled32 group instead of the unscaled group.

This fixes PandABlocks/PandABlocks-server#47