### PR TITLE
Remove support for .MIN value on time fields

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -71,7 +71,7 @@ Field
 ``param`` field-subtype [ ``=`` value ]
 ``read`` field-subtype
 ``write`` field-subtype
-``time`` [ ``>`` min_value ]
+``time``
 ``bit_out``
 ``pos_out`` [ scale [ offset [ units ]]]
 ``ext_out`` ( ``timestamp`` | ``samples`` | ``bits`` group )
@@ -96,13 +96,9 @@ Field
     actions on a block.  The `field-subtype` must be specified, and the `action`
     subtype is useful for ``write`` fields which take no data.
 
-``time`` [ ``>`` min_value ]
+``time``
     Time fields behave like ``param`` fields, but need special treatment because
     the underlying value is 64-bits and so two registers need to be written.
-
-    If desired a minimum valid value can be specified as `min_value`.  This will
-    prevent the writing of values less than this value and can be read as the
-    ``.MIN`` attribute.
 
 ``bit_out``
     This identifies an output bit.

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -127,10 +127,6 @@ Field type          Description
         This attribute can be read or written to report or set the delay in FPGA
         ticks.
 
-    ``MIN``
-        This reports the minimum valid value for this field in the currently
-        selected units.
-
     The ``UNITS`` attribute determines how numbers read or written to the field
     are interpreted.  For example::
 
@@ -466,7 +462,6 @@ scalar          RAW             Underlying integer value                R W
 lut             RAW             Computed Lookup Table 32-bit value      R
 time            UNITS           Units and scaling selection for time    R W C
 \               RAW             Raw time in FPGA clock cycles           R W
-\               MIN             Minimum valid setting (for type only)   R
 bit_out         CAPTURE_WORD    Capturable word containing this bit     R
 \               OFFSET          Offset of this bit in captured word     R
 bit_mux         DELAY           Bit input delay in FPGA ticks           R W C

--- a/python/sim_config/registers
+++ b/python/sim_config/registers
@@ -39,8 +39,8 @@ DIV         9
     COUNT           4
 
 PULSE       10
-    DELAY           3 2     >3
-    WIDTH           5 4     >3
+    DELAY           3 2
+    WIDTH           5 4
     INP             0 11
     ENABLE          1 12
     OUT             30 31 32 33


### PR DESCRIPTION
This will fix issues #48 and #30 in the simplest possible way!