### PR TITLE
Replace two occurrences of `sizeof(*p)` with explicit structures

### DIFF
--- a/driver/panda_block.c
+++ b/driver/panda_block.c
@@ -401,7 +401,7 @@ irqreturn_t block_isr(int irq, void *dev_id)
 static int panda_block_open(struct inode *inode, struct file *file)
 {
     int rc = 0;
-    struct block_open *open = kmalloc(sizeof(*open), GFP_KERNEL);
+    struct block_open *open = kmalloc(sizeof(struct block_open), GFP_KERNEL);
     TEST_PTR(open, rc, no_open, "Unable to allocate open structure");
 
     *open = (struct block_open) {

--- a/driver/panda_stream.c
+++ b/driver/panda_stream.c
@@ -331,7 +331,8 @@ static int panda_stream_open(struct inode *inode, struct file *file)
 
     int rc = 0;
     struct stream_open *open = kmalloc(
-        sizeof(*open) + block_count * sizeof(struct block), GFP_KERNEL);
+        sizeof(struct stream_open) +
+        block_count * sizeof(struct block), GFP_KERNEL);
     TEST_PTR(open, rc, no_open, "Unable to allocate open structure");
 
     file->private_data = open;


### PR DESCRIPTION
Have been bitten by this in the past, this isn't a safe idiom