### PR TITLE
extension-server: run in a loop to fix panda server restarting

### DIFF
--- a/python/extension_server
+++ b/python/extension_server
@@ -142,11 +142,12 @@ class Extensions:
 
 
 class Server:
-    def __init__(self, port):
+    def __init__(self, port, loop):
         self.server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.server_sock.bind(('localhost', port))
         self.server_sock.listen(1)
+        self.loop = loop
         # Will be filled in by self.run()
         self.file = None
         self.ext = None
@@ -200,15 +201,22 @@ class Server:
                     message = 'Extension server exception'
                 self.send('E%s\n' % message)
 
+        self.file.close()
+
     def run(self):
-        conn, _ = self.server_sock.accept()
+        while True:
+            conn, _ = self.server_sock.accept()
+            conn.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
+            self.file = conn.makefile('rw')
+            self.ext = Extensions()
+
+            self.run_service()
+
+            conn.close()
+            if not self.loop:
+                break
+
         self.server_sock.close()
-
-        conn.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
-        self.file = conn.makefile('rw')
-        self.ext = Extensions()
-
-        self.run_service()
 
 
 def close_inherited_files():
@@ -270,6 +278,9 @@ parser.add_argument(
     help = 'Normalise exception messages reported by server.  Testing only')
 parser.add_argument(
     'extensions', help = 'Extension directory')
+parser.add_argument(
+    '--loop', action = 'store_true',
+    help = 'Keep running after connection closed.')
 command_args = parser.parse_args()
 
 
@@ -299,7 +310,7 @@ sys.path.insert(0, extension_dir)
 
 
 # Create the server right away and listen for one connection.
-server = Server(command_args.port)
+server = Server(command_args.port, command_args.loop)
 logging.info('Extension server ready')
 
 # Need to daemonise after the listening port is ready but before calling accept.

--- a/server/base64.c
+++ b/server/base64.c
@@ -6,7 +6,7 @@
 #include "base64.h"
 
 /* Encoding lookup table. */
-static const char encode[64] =
+static const char encode[64] __attribute__((nonstring)) =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 /* Decode lookup table, setup during initialisation. */


### PR DESCRIPTION
Whenever the panda server restarts, the extension server exits and before
it has time to start again, the server fails to connect to it. This
has been fixed by running the extension server in a loop.

EDIT: I made it optional (enabled by argument) because tests are currently relying on the one time run behavior