### PR TITLE
CI: bump myst-version-switcher-plugin to v0.22.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   # --- Docs build (every event; never publishes) ------------------------------
   docs:
-    uses: DiamondLightSource/myst-version-switcher-plugin/.github/workflows/docs.yml@v0.18.0
+    uses: DiamondLightSource/myst-version-switcher-plugin/.github/workflows/docs.yml@v0.22.0
     with:
       # `make docs` reads build settings (incl. MYSTMD_VERSION) from CONFIG; docs.yml
       # sets BASE_URL and packs/uploads the docs.zip artifact.
@@ -51,7 +51,7 @@ jobs:
   release:
     needs: [lint, test, docs]
     if: github.ref_type == 'tag'
-    uses: DiamondLightSource/myst-version-switcher-plugin/.github/workflows/release.yml@v0.18.0
+    uses: DiamondLightSource/myst-version-switcher-plugin/.github/workflows/release.yml@v0.22.0
     permissions:
       contents: write    # create the GitHub Release + attach assets
 

--- a/.github/workflows/publish-dispatch.yml
+++ b/.github/workflows/publish-dispatch.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   publish:
-    uses: DiamondLightSource/myst-version-switcher-plugin/.github/workflows/publish.yml@v0.18.0
+    uses: DiamondLightSource/myst-version-switcher-plugin/.github/workflows/publish.yml@v0.22.0
     with:
       version-name: ${{ inputs.version-name }}   # "" on dispatch → pure durable gather
       pr: ${{ inputs.pr }}                        # set (dispatch only) → pin that fork head SHA

--- a/.github/workflows/publish-dispatch.yml
+++ b/.github/workflows/publish-dispatch.yml
@@ -23,6 +23,12 @@ on:
         description: External fork PR number to approve (pins its head SHA) and preview. Leave empty to just re-deploy.
         required: false
         default: ""
+      retry-until:
+        description: >-
+          Internal — epoch-seconds deadline for auto-retrying a wedged Pages origin.
+          Don't set manually.
+        required: false
+        default: ""
 
 jobs:
   publish:
@@ -31,6 +37,7 @@ jobs:
       version-name: ${{ inputs.version-name }}   # "" on dispatch → pure durable gather
       pr: ${{ inputs.pr }}                        # set (dispatch only) → pin that fork head SHA
       dispatch-workflow: publish-dispatch.yml     # the file the tag re-dispatch re-fires
+      retry-until: ${{ inputs.retry-until }}      # "" on workflow_call/no-retry dispatch → no auto-retry
     permissions:
       contents: read
       actions: write     # publish.yml's re-dispatch job re-fires this shim via gh

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -3,7 +3,7 @@ project:
   title: PandABlocks-server
   github: https://github.com/PandABlocks/PandABlocks-server
   plugins:
-    - https://github.com/DiamondLightSource/myst-version-switcher-plugin/releases/download/v0.18.0/version-switcher.mjs
+    - https://github.com/DiamondLightSource/myst-version-switcher-plugin/releases/download/v0.22.0/version-switcher.mjs
   # Cross-repository references (mystmd xref + Sphinx intersphinx).
   # PROTOTYPE for upstreaming into the DLS python-copier-template (Stage A spec §6).
   #


### PR DESCRIPTION
## Summary
- Bump the pinned `DiamondLightSource/myst-version-switcher-plugin` reusable workflows (`docs.yml`, `release.yml`, `publish.yml`) and the in-page switcher plugin asset from v0.18.0 to v0.22.0.
- Picks up v0.19.0–v0.22.0: release-by-tag docs fixes, simplified publish gather logic, filename-agnostic gather/custom domains/Sphinx support, and an auto-retry when the Pages origin wedges. No breaking changes in the upstream changelog.

## Test plan
- [ ] CI green (lint/test/docs/release jobs)